### PR TITLE
Add a few tweaks to make the program more useful when included elsewhere

### DIFF
--- a/programs/multisig/Cargo.toml
+++ b/programs/multisig/Cargo.toml
@@ -3,6 +3,7 @@ name = "serum-multisig"
 version = "0.5.0"
 description = "Created with Anchor"
 edition = "2018"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -23,7 +23,7 @@ use anchor_lang::solana_program::instruction::Instruction;
 use std::convert::Into;
 
 #[program]
-pub mod serum_multisig {
+pub mod serum_multisig_impl {
     use super::*;
 
     // Initializes a new multisig account with a set of owners and a threshold.

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -230,35 +230,35 @@ pub struct ExecuteTransaction<'info> {
 
 #[account]
 pub struct Multisig {
-    owners: Vec<Pubkey>,
-    threshold: u64,
-    nonce: u8,
-    owner_set_seqno: u32,
+    pub owners: Vec<Pubkey>,
+    pub threshold: u64,
+    pub nonce: u8,
+    pub owner_set_seqno: u32,
 }
 
 #[account]
 pub struct Transaction {
     // The multisig account this transaction belongs to.
-    multisig: Pubkey,
+    pub multisig: Pubkey,
     // Target program to execute against.
-    program_id: Pubkey,
+    pub program_id: Pubkey,
     // Accounts requried for the transaction.
-    accounts: Vec<TransactionAccount>,
+    pub accounts: Vec<TransactionAccount>,
     // Instruction data for the transaction.
-    data: Vec<u8>,
+    pub data: Vec<u8>,
     // signers[index] is true iff multisig.owners[index] signed the transaction.
-    signers: Vec<bool>,
+    pub signers: Vec<bool>,
     // Boolean ensuring one time execution.
-    did_execute: bool,
+    pub did_execute: bool,
     // Owner set sequence number.
-    owner_set_seqno: u32,
+    pub owner_set_seqno: u32,
 }
 
 impl From<&Transaction> for Instruction {
     fn from(tx: &Transaction) -> Instruction {
         Instruction {
             program_id: tx.program_id,
-            accounts: tx.accounts.clone().into_iter().map(Into::into).collect(),
+            accounts: tx.accounts.iter().map(AccountMeta::from).collect(),
             data: tx.data.clone(),
         }
     }
@@ -266,16 +266,26 @@ impl From<&Transaction> for Instruction {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct TransactionAccount {
-    pubkey: Pubkey,
-    is_signer: bool,
-    is_writable: bool,
+    pub pubkey: Pubkey,
+    pub is_signer: bool,
+    pub is_writable: bool,
 }
 
-impl From<TransactionAccount> for AccountMeta {
-    fn from(account: TransactionAccount) -> AccountMeta {
+impl From<&TransactionAccount> for AccountMeta {
+    fn from(account: &TransactionAccount) -> AccountMeta {
         match account.is_writable {
             false => AccountMeta::new_readonly(account.pubkey, account.is_signer),
             true => AccountMeta::new(account.pubkey, account.is_signer),
+        }
+    }
+}
+
+impl From<&AccountMeta> for TransactionAccount {
+    fn from(account_meta: &AccountMeta) -> TransactionAccount {
+        TransactionAccount {
+            pubkey: account_meta.pubkey,
+            is_signer: account_meta.is_signer,
+            is_writable: account_meta.is_writable,
         }
     }
 }

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -166,7 +166,7 @@ pub mod serum_multisig {
         ];
         let signer = &[&seeds[..]];
         let accounts = ctx.remaining_accounts;
-        solana_program::program::invoke_signed(&ix, &accounts, signer)?;
+        solana_program::program::invoke_signed(&ix, accounts, signer)?;
 
         // Burn the transaction to ensure one time use.
         ctx.accounts.transaction.did_execute = true;


### PR DESCRIPTION
First of all, thank you for building this program. We use it for [Lido for Solana](https://github.com/ChorusOne/solido) and it’s been very valuable.

There were a few changes we had to make to be able to include it in our project, that might benefit others as well.

* Make struct fields public, so you can include the crate and deserialize the types within a different crate.
* Make the `From` impl non-destructive and add the reverse impl as well.
* Set the license in the metadata, so `cargo-license` can find it.
* Apply a `clippy` suggestion.
* Rename the `#[program]` mod to avoid the following error in `cargo test-bpf`:

  ```
     Doc-tests serum_multisig
  error[E0659]: `serum_multisig` is ambiguous (name vs any other name during import resolution)
     -->programs/multisig/src/lib.rs:26:9
      |
  26  | pub mod serum_multisig {
      |         ^^^^^^^^^^^^^^ ambiguous name
      |
      = note: `serum_multisig` could refer to a crate passed with `--extern`
      = help: use `::serum_multisig` to refer to this crate unambiguously
  note: `serum_multisig` could also refer to the module defined here
     --> programs/multisig/src/lib.rs:26:1
      |
  26  | / pub mod serum_multisig {
  27  | |     use super::*;
  28  | |
  29  | |     // Initializes a new multisig account with a set of owners and a threshold.
  ...   |
  175 | |     }
  176 | | }
      | |_^
      = help: use `crate::serum_multisig` to refer to this module unambiguously
  
  error: aborting due to previous error
  ```

    I’m not sure if there is a better way to avoid that problem, but renaming the mod so the name differs from the crate name makes the error go away.