### PR TITLE
Add signer requirement to multisig

### DIFF
--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -185,7 +185,7 @@ pub mod serum_multisig {
 
 #[derive(Accounts)]
 pub struct CreateMultisig<'info> {
-    #[account(zero)]
+    #[account(zero, signer)]
     multisig: ProgramAccount<'info, Multisig>,
     rent: Sysvar<'info, Rent>,
 }


### PR DESCRIPTION
Currently, the program makes the same assumption as the SPL token program when initializing accounts. Namely, that one atomically creates + initializes in two instructions in the same transaction.

The changes here relax that requirement by requiring the multisig account to sign when being initialized. This will allow one to create and initialize in two different transactions--though I expect this use case to be uncommon.