### PR TITLE
ci: add fmt and clippy, use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,5 @@ jobs:
     - <<: *defaults
       name: Cargo fmt & clippy
       script:
-        - rustup component add rustfmt clippy
-        - rustup component list
-        - cargo-fmt --help
-        - cargo-fmt --all --check
+        - cargo-fmt --all -- --check
         - cargo clippy --all-targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ jobs:
       name: Cargo fmt & clippy
       script:
         - rustup component add rustfmt clippy
-        - cargo fmt --all --check
+        - cargo-fmt --all --check
         - cargo clippy --all-targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,6 @@ jobs:
     - <<: *defaults
       name: Cargo fmt & clippy
       script:
+        - rustup component add rustfmt clippy
         - cargo fmt --all --check
         - cargo clippy --all-targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,6 @@ jobs:
     - <<: *defaults
       name: Cargo fmt & clippy
       script:
+        - rustup component add rustfmt clippy
         - cargo-fmt --all -- --check
         - cargo clippy --all-targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,21 @@ deploy:
 _defaults: &defaults
   before_install:
   - nvm install $NODE_VERSION
-  - npm install -g mocha
-  - npm install -g @project-serum/anchor
+  - npm ci
   - sudo apt-get install -y pkg-config build-essential libudev-dev
   - sh -c "$(curl -sSfL https://release.solana.com/${SOLANA_VERSION}/install)"
   - export PATH="/home/travis/.local/share/solana/install/active_release/bin:$PATH"
   - export NODE_PATH="/home/travis/.nvm/versions/node/${NODE_VERSION}/lib/node_modules/:${NODE_PATH}"
   - yes | solana-keygen new
-  - cargo install --git https://github.com/project-serum/anchor --tag ${ANCHOR_VERSION} anchor-cli --locked
 
 jobs:
   include:
     - <<: *defaults
       name: Runs the tests
       script:
-        - anchor test
+        - npx anchor test
+    - <<: *defaults
+      name: Cargo fmt & clippy
+      script:
+        - cargo fmt --all --check
+        - cargo clippy --all-targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
       name: Cargo fmt & clippy
       script:
         - rustup component add rustfmt clippy
+        - rustup component list
         - cargo-fmt --help
         - cargo-fmt --all --check
         - cargo clippy --all-targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,6 @@ jobs:
       name: Cargo fmt & clippy
       script:
         - rustup component add rustfmt clippy
+        - cargo-fmt --help
         - cargo-fmt --all --check
         - cargo clippy --all-targets

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -37,7 +37,7 @@ pub mod serum_multisig {
     ) -> Result<()> {
         assert_unique_owners(&owners)?;
         require!(threshold > 0, InvalidThreshold);
-        require!(owners.len() > 0, InvalidOwnersLen);
+        require!(!owners.is_empty(), InvalidOwnersLen);
 
         let multisig = &mut ctx.accounts.multisig;
         multisig.owners = owners;
@@ -111,7 +111,7 @@ pub mod serum_multisig {
     // is via a recursive call from execute_transaction -> set_owners.
     pub fn set_owners(ctx: Context<Auth>, owners: Vec<Pubkey>) -> Result<()> {
         assert_unique_owners(&owners)?;
-        require!(owners.len() > 0, InvalidOwnersLen);
+        require!(!owners.is_empty(), InvalidOwnersLen);
 
         let multisig = &mut ctx.accounts.multisig;
 


### PR DESCRIPTION
- Use `anchor` from `npm` package instead building from sources.
- Add fmt & clippy.