### PR TITLE
Add unapprove instruction

### DIFF
--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -97,6 +97,21 @@ pub mod serum_multisig {
         Ok(())
     }
 
+    // Unapproves a transaction on behalf of an owner of the multisig.
+    pub fn unapprove(ctx: Context<Unapprove>) -> Result<()> {
+        let owner_index = ctx
+            .accounts
+            .multisig
+            .owners
+            .iter()
+            .position(|a| a == ctx.accounts.owner.key)
+            .ok_or(ErrorCode::InvalidOwner)?;
+
+        ctx.accounts.transaction.signers[owner_index] = false;
+
+        Ok(())
+    }
+
     // Set owners and threshold at once.
     pub fn set_owners_and_change_threshold<'info>(
         ctx: Context<'_, '_, '_, 'info, Auth<'info>>,
@@ -206,6 +221,17 @@ pub struct CreateTransaction<'info> {
 
 #[derive(Accounts)]
 pub struct Approve<'info> {
+    #[account(constraint = multisig.owner_set_seqno == transaction.owner_set_seqno)]
+    multisig: ProgramAccount<'info, Multisig>,
+    #[account(mut, has_one = multisig)]
+    transaction: ProgramAccount<'info, Transaction>,
+    // One of the multisig owners. Checked in the handler.
+    #[account(signer)]
+    owner: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct Unapprove<'info> {
     #[account(constraint = multisig.owner_set_seqno == transaction.owner_set_seqno)]
     multisig: ProgramAccount<'info, Multisig>,
     #[account(mut, has_one = multisig)]


### PR DESCRIPTION
Reverse of `approve` (I just copied `approve` and flipped the bool), allows a signer to undo a previous approval.