### PR TITLE
add check on transaction creation

### DIFF
--- a/tests/multisig.js
+++ b/tests/multisig.js
@@ -69,6 +69,7 @@ describe("multisig", () => {
         multisig: multisig.publicKey,
         transaction: transaction.publicKey,
         proposer: ownerA.publicKey,
+        multisigSigner
       },
       instructions: [
         await program.account.transaction.createInstruction(
@@ -104,7 +105,6 @@ describe("multisig", () => {
     await program.rpc.executeTransaction({
       accounts: {
         multisig: multisig.publicKey,
-        multisigSigner,
         transaction: transaction.publicKey,
       },
       remainingAccounts: program.instruction.setOwners
@@ -165,7 +165,7 @@ describe("multisig", () => {
     } catch (err) {
       const error = err.error;
       assert.strictEqual(error.errorCode.number, 6008);
-      assert.strictEqual(error.errorMessage, "Owners must be unique");
+      assert.strictEqual(error.errorMessage, "Owners must be unique.");
     }
   });
 });


### PR DESCRIPTION
Hello,

I'm making a series of pull request. Feel free to refuse the ones that aren't meaningful to you.

This pull request updates the instructions `create_transaction` and `execute_transaction`.

The instruction `create_transaction` now ensures that the `multisig_signer` account is present as a signer in the account list.
I removed the `multisig_signer` account in the `execute_transaction` instruction, as it is already included in the "remaining accounts".

Pros:
- Transaction where the multisig_signer account is not present or not a signer are refused.
- ExecuteTransaction instruction size is now smaller and consumes less compute units.

Con:
- Require frontend apps to update their code