### PR TITLE
Simplify some code in transaction execution

### DIFF
--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -168,17 +168,11 @@ pub mod coral_multisig {
 
         // Execute the transaction signed by the multisig.
         let mut ix: Instruction = (*ctx.accounts.transaction).deref().into();
-        ix.accounts = ix
-            .accounts
-            .iter()
-            .map(|acc| {
-                let mut acc = acc.clone();
-                if &acc.pubkey == ctx.accounts.multisig_signer.key {
-                    acc.is_signer = true;
-                }
-                acc
-            })
-            .collect();
+        for acc in ix.accounts.iter_mut() {
+            if &acc.pubkey == ctx.accounts.multisig_signer.key {
+                acc.is_signer = true;
+            }
+        }
         let multisig_key = ctx.accounts.multisig.key();
         let seeds = &[multisig_key.as_ref(), &[ctx.accounts.multisig.nonce]];
         let signer = &[&seeds[..]];


### PR DESCRIPTION
Hello, if anyone's out there :wave:

I'm not sure if anyone uses this repo in production but it still seems like a repo that people use to learn Anchor, judging by the 100 forks and my own personal experience.

Case in point, I'm working on a timelock program & ended up re-using a lot of the code from this repo. When I was looking at this part of it though, I realized that you could accomplish this in a way that was more simple and efficient. I've measured it and it removes 285 CUs in these tests.

I think this provides pedagogical value even if this repo isn't being used in prod.